### PR TITLE
Maven build migration actions

### DIFF
--- a/.github/actions/build-migration/action.yml
+++ b/.github/actions/build-migration/action.yml
@@ -1,0 +1,51 @@
+name: Maven Build
+description: Run a Maven Build
+
+inputs:
+  build-command:
+    description: The Maven command to build the project. The default is `package`.
+    required: false
+    # type: string  - `type` field is not supported (yet). See comment below.
+    default: install
+  release-name:
+    description: The Maven artifact name and version.
+    required: true
+  build-flags: 
+    description: The Maven build flags
+    required: false
+    default: '-Dmaven.repo.local=$GITHUB_WORKSPACE/.m2' # why the local artifactory is required 
+  #deploy-flags: #compose from build-flags and maven-settings
+  #  description: The Maven deploy flags
+  #  required: false
+  #  default: '-s $GITHUB_WORKSPACE/settings.xml -Dmaven.repo.local=$GITHUB_WORKSPACE/.m2' # not required since actions/setup-java allows the definition of the settings file path and build-flags already define the ref to the local artifactory
+  build-profiles:
+    description: The maven build profiles
+    required: false
+    default: 'daml,scala,typescript,golang,csharp8,csharp9,kotlin,python,full,gpg,excel' # TBD whether this is useful for the parallel build tasks
+  maven-settings:
+    description: The Maven settings file
+    required: false
+    default: $GITHUB_WORKSPACE
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up JDK 11 for x64
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        architecture: x64
+        cache: maven
+        server-id: ossrh
+        server-username: CI_DEPLOY_USERNAME
+        server-password: CI_DEPLOY_PASSWORD
+        settings-path: ${{inputs.maven-settings}}
+        gpg-private-key: GPG_PRIVATE_KEY
+        gpg-passphrase: GPG_PASSPHRASE
+    - name: Set artifact version with Maven
+      shell: bash
+      run: mvn ${{inputs.build-flags}} versions:set -DnewVersion=${{inputs.release-name}} versions:update-child-modules -DallowSnapshots=true 
+    - name: Build and deploy artifact with Maven
+      shell: bash
+      run: mvn ${{inputs.build-flags}} clean ${{inputs.build-command}} -P ${{inputs.build-profiles}}

--- a/.github/workflows/build-migration-dev.yml
+++ b/.github/workflows/build-migration-dev.yml
@@ -1,27 +1,24 @@
 name: Java CI with Maven
 
 on:
-  push:
-    branches: [ "master", "develop" ]
-  pull_request:
-    branches: [ "master", "develop" ]
- 
+  push: #triggers on tag push event
+    tags:
+      - '**'
+  pull_request: #triggers on PR merge event into develop branch
+    types:
+      - closed
+    
 jobs:
   setup: # defines the variables used across all job's steps and output variables to be used across jobs.
     runs-on: ubuntu-latest
     env:  # environment variables used across the setup job
-      # GPG config demo - TBD: proposal using secrets
-      REPO_PATH: "$GITHUB_WORKSPACE" # Not required
-      MVN_DEPLOY_FLAGS: "-s $GITHUB_WORKSPACE/settings.xml -Dmaven.repo.local=$GITHUB_WORKSPACE/.m2 -Denv.CI_DEPLOY_PASSWORD=$GITHUB_TOKEN -Denv.CI_DEPLOY_USERNAME=$GITHUB_USER -Denv.GPG_KEYNAME=${{secrets.GPG_KEYNAME}} -Denv.GPG_PASSPHRASE=${{secrets.GPG_PASSPHRASE}}"
       MVN_BUILD_FLAGS: "-Dmaven.repo.local=$GITHUB_WORKSPACE/.m2"
-      # GPG_IMPORT_COMMAND: "cat <(echo -e '${{secrets.GPG_PRIVATE_KEY}}') | gpg --batch --import" - can be used if GPG is handled through secrets. 
+      MVN_DEPLOY_FLAGS: "-s $GITHUB_WORKSPACE/settings.xml"
       GEN_DEPLOY_POM_SCRIPT: "$GITHUB_WORKSPACE/rosetta-source/src/main/resources/build-resources/create-deploy-pom.sh"
       GEN_DEPLOY_POM_PY: "$GITHUB_WORKSPACE/rosetta-source/src/main/resources/build-resources/create-deploy-pom.py"
     outputs:
-      REPO_PATH: ${{env.REPO_PATH}}
-      MVN_DEPLOY_FLAGS: ${{env.MVN_DEPLOY_FLAGS}}
       MVN_BUILD_FLAGS: ${{env.MVN_BUILD_FLAGS}}
-      GPG_IMPORT_COMMAND: ${{steps.set_props.outputs.GPG_IMPORT_COMMAND}}
+      MVN_DEPLOY_FLAGS: ${{env.MVN_DEPLOY_FLAGS}}
       RELEASE_NAME: ${{steps.release_props.outputs.RELEASE_NAME}}
       RELEASE_MAVEN_BUILD_PROFILES: ${{steps.release_props.outputs.MAVEN_BUILD_PROFILES}}
       RELEASE_MVN_DEPLOY_FILE_FLAGS: ${{steps.release_props.outputs.MVN_DEPLOY_FILE_FLAGS}}
@@ -31,63 +28,71 @@ jobs:
  
     steps:
       - name: main_clone
-        uses: actions/checkout@v2
-      
-      - name: SetProperties
-        id: set_props
-        shell: bash
-        run: echo "GPG_IMPORT_COMMAND=${{env.GPG_IMPORT_COMMAND}}" >> "$GITHUB_OUTPUT"
-        env:
-          GPG_IMPORT_COMMAND: "cat <(echo -e '${{secrets.GPG_PRIVATE_KEY}}') | gpg --batch --import"
+        uses: actions/checkout@v4
 
       - name: ReleaseProperties
         id: release_props
-        if: "contains(github.ref, 'master')"
+        if: startsWith(github.ref, 'refs/tags')
         shell: bash
         run: |
-          echo "=== Global variable resolution ==="
-          echo "REPO_PATH: ${{env.REPO_PATH}}"
-          echo "=== Local variable resolution ==="
           echo "RELEASE_NAME=${{env.RELEASE_NAME}}" >> "$GITHUB_OUTPUT"
-          echo "MAVEN_BUILD_PROFILES=${{env.MAVEN_BUILD_PROFILES}}" >> "$GITHUB_OUTPUT"
-          echo "MVN_DEPLOY_FILE_FLAGS=${{env.MVN_DEPLOY_FILE_FLAGS}}" >> "$GITHUB_OUTPUT"
+          echo "RELEASE_MAVEN_BUILD_PROFILES=${{env.MAVEN_BUILD_PROFILES}}" >> "$GITHUB_OUTPUT"
+          echo "RELEASE_MVN_DEPLOY_FILE_FLAGS=${{env.MVN_DEPLOY_FILE_FLAGS}}" >> "$GITHUB_OUTPUT"
         env:
-          RELEASE_NAME: "${{github.ref_name}}" # not resoled hot to define release name (e.g. $github.tag)
+          RELEASE_NAME: "${{github.event.release.tag_name}}"
           MAVEN_BUILD_PROFILES: "daml,scala,typescript,golang,csharp8,csharp9,kotlin,python,full,gpg,excel"
-          MVN_DEPLOY_FILE_FLAGS: "${{env.MVN_BUILD_FLAGS}} ${{env.MVN_DEPLOY_FLAGS}} -Durl=https://oss.sonatype.org/service/local/staging/deploy/maven2 -DrepositoryId=ossrh-distro -Dgpg.passphrase=${{env.GPG_PASSPHRASE}}"
+          MVN_DEPLOY_FILE_FLAGS: "${{env.MVN_BUILD_FLAGS}} ${{env.MVN_DEPLOY_FLAGS}} -Durl=https://oss.sonatype.org/service/local/staging/deploy/maven2 -DrepositoryId=ossrh-distro"
           
       - name: SnapshotProperties
         id: snapshot_props
-        if: "contains(github.ref, 'develop')"
+        if: github.ref == 'refs/heads/develop' && github.event.pull_request.merged == true
         shell: bash
         run: |
-          echo "=== Global variable resolution ==="
-          echo "REPO_PATH: ${{env.REPO_PATH}}"
-          echo "=== Local variable resolution ==="
-          echo "RELEASE_NAME=${{env.RELEASE_NAME}}" >> "$GITHUB_OUTPUT"
-          echo "MAVEN_BUILD_PROFILES=${{env.MAVEN_BUILD_PROFILES}}" >> "$GITHUB_OUTPUT"
-          echo "MVN_DEPLOY_FILE_FLAGS=${{env.MVN_DEPLOY_FILE_FLAGS}}" >> "$GITHUB_OUTPUT"
+          echo "SNAPSHOT_NAME=${{env.RELEASE_NAME}}" >> "$GITHUB_OUTPUT"
+          echo "SNAPSHOT_MAVEN_BUILD_PROFILES=${{env.MAVEN_BUILD_PROFILES}}" >> "$GITHUB_OUTPUT"
+          echo "SNAPSHOT_MVN_DEPLOY_FILE_FLAGS=${{env.MVN_DEPLOY_FILE_FLAGS}}" >> "$GITHUB_OUTPUT"
         env:
           RELEASE_NAME: "${{github.ref_name}}-SNAPSHOT" # not resolved how to define snapshot name
           MAVEN_BUILD_PROFILES: "daml,scala,typescript,golang,csharp8,csharp9,kotlin,python,gpg,excel"
-          MVN_DEPLOY_FILE_FLAGS: "${{env.MVN_BUILD_FLAGS}} ${{env.MVN_DEPLOY_FLAGS}} -Durl=https://oss.sonatype.org/content/repositories/snapshots -DrepositoryId=ossrh -Dgpg.passphrase=${{env.GPG_PASSPHRASE}}"
+          MVN_DEPLOY_FILE_FLAGS: "${{env.MVN_BUILD_FLAGS}} ${{env.MVN_DEPLOY_FLAGS}} -Durl=https://oss.sonatype.org/content/repositories/snapshots -DrepositoryId=ossrh"
 
   build:
     needs: setup
     runs-on: ubuntu-latest # Not resolved - Maven image required
 
     steps:
+      - uses: actions/checkout@v4
       - name: Build Release CI
-        if: "contains(github.ref, 'master')"
-        run: |
-          echo "MVN_DEPLOY_FILE_FLAGS: ${{needs.setup.outputs.RELEASE_MVN_DEPLOY_FILE_FLAGS}}"
-          echo "RELEASE_NAME: ${{needs.setup.outputs.RELEASE_NAME}}"
+        if: startsWith(github.event.ref, 'refs/tags')
+        uses: ./.github/actions/build-migration
+        with:
+          build-command: install
+          release-name: ${{needs.setup.outputs.RELEASE_NAME}}
+          build-flags: ${{needs.setup.outputs.MVN_BUILD_FLAGS}}
+          build-profiles: ${{needs.setup.outputs.RELEASE_MVN_DEPLOY_FILE_FLAGS}}
+          maven-settings: $GITHUB_WORKSPACE/settings.xml
+        env:
+          GPG_KEYNAME: ${{secrets.GPG_KEYNAME}}
+          GPG_PRIVATE_KEY: ${{secrets.GPG_PRIVATE_KEY}}
+          GPG_PASSPHRASE: ${{secrets.GPG_PASSPHRASE}}
+          CI_DEPLOY_USERNAME: ${{secrets.CI_DEPLOY_USERNAME}}
+          CI_DEPLOY_PASSWORD: ${{secrets.CI_DEPLOY_PASSWORD}}
 
       - name: Build Snapshot CI
-        if: "contains(github.ref, 'develop')"
-        run: |
-          echo "MVN_DEPLOY_FILE_FLAGS: ${{needs.setup.outputs.SNAPSHOT_MVN_DEPLOY_FILE_FLAGS}}"
-          echo "RELEASE_NAME: ${{needs.setup.outputs.SNAPSHOT_NAME}}"
+        if: github.ref == 'refs/heads/develop' && github.event.pull_request.merged == true
+        uses: ./.github/actions/build-migration
+        with:
+          build-command: verify
+          release-name: ${{needs.setup.outputs.SNAPSHOT_NAME}}
+          build-flags: ${{needs.setup.outputs.MVN_BUILD_FLAGS}}
+          build-profiles: ${{needs.setup.outputs.SNAPSHOT_MVN_DEPLOY_FILE_FLAGS}}
+          maven-settings: $GITHUB_WORKSPACE/settings.xml
+        env:
+          GPG_KEYNAME: ${{secrets.GPG_KEYNAME}}
+          GPG_PRIVATE_KEY: ${{secrets.GPG_PRIVATE_KEY}}
+          GPG_PASSPHRASE: ${{secrets.GPG_PASSPHRASE}}
+          CI_DEPLOY_USERNAME: ${{secrets.CI_DEPLOY_USERNAME}}
+          CI_DEPLOY_PASSWORD: ${{secrets.CI_DEPLOY_PASSWORD}}
   
   distribute:
     needs: build
@@ -97,7 +102,7 @@ jobs:
       # Steps for distribution if needed
       - name: Distribute CI
         run:
-          echo "Testing distribute ci"
+          echo "Distribute ci"
   
   finalise:
     needs: distribute
@@ -107,4 +112,4 @@ jobs:
       # Steps for finalizing the process if needed
       - name: Finalize CI
         run:
-          echo "Testing finalize ci"
+          echo "Finalize ci"


### PR DESCRIPTION
# Description
- Action created under .github/actions/build-migration: Handles maven build and deployment using github secrets. 
- Migration dev workflow triggers snapshot steps on PR merges and release steps on tag push event.
- Migration dev workflow uses build-migration action with mvn verify (snapshot) and mvn install (release)

# Detected Issues
- GPG import commands couldn't be verified without valid keys
- Release and snapshot names not being resolved properly